### PR TITLE
Unset current devspace when appropriate

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -20,7 +20,7 @@ $ npm install -g @formicarium/cli
 $ fmc COMMAND
 running command...
 $ fmc (-v|--version|version)
-@formicarium/cli/1.4.26 darwin-x64 node-v11.9.0
+@formicarium/cli/1.4.27 darwin-x64 node-v11.9.0
 $ fmc --help [COMMAND]
 USAGE
   $ fmc COMMAND
@@ -66,7 +66,7 @@ EXAMPLES
   $ fmc curl POST purgatory /do/something -d '{...}'
 ```
 
-_See code: [src/commands/curl.ts](https://github.com/formicarium/fmc/blob/v1.4.26/src/commands/curl.ts)_
+_See code: [src/commands/curl.ts](https://github.com/formicarium/fmc/blob/v1.4.27/src/commands/curl.ts)_
 
 ## `fmc devspace:create ID`
 
@@ -85,7 +85,7 @@ EXAMPLES
   $ fmc devspace:create acq --arg sharded
 ```
 
-_See code: [src/commands/devspace/create.ts](https://github.com/formicarium/fmc/blob/v1.4.26/src/commands/devspace/create.ts)_
+_See code: [src/commands/devspace/create.ts](https://github.com/formicarium/fmc/blob/v1.4.27/src/commands/devspace/create.ts)_
 
 ## `fmc devspace:delete NAME`
 
@@ -102,7 +102,7 @@ EXAMPLE
   $ fmc devspace:delete paps
 ```
 
-_See code: [src/commands/devspace/delete.ts](https://github.com/formicarium/fmc/blob/v1.4.26/src/commands/devspace/delete.ts)_
+_See code: [src/commands/devspace/delete.ts](https://github.com/formicarium/fmc/blob/v1.4.27/src/commands/devspace/delete.ts)_
 
 ## `fmc devspace:info`
 
@@ -119,7 +119,7 @@ EXAMPLE
   $ fmc devspace:info
 ```
 
-_See code: [src/commands/devspace/info.ts](https://github.com/formicarium/fmc/blob/v1.4.26/src/commands/devspace/info.ts)_
+_See code: [src/commands/devspace/info.ts](https://github.com/formicarium/fmc/blob/v1.4.27/src/commands/devspace/info.ts)_
 
 ## `fmc devspace:list`
 
@@ -136,7 +136,7 @@ EXAMPLE
   $ fmc devspace:list
 ```
 
-_See code: [src/commands/devspace/list.ts](https://github.com/formicarium/fmc/blob/v1.4.26/src/commands/devspace/list.ts)_
+_See code: [src/commands/devspace/list.ts](https://github.com/formicarium/fmc/blob/v1.4.27/src/commands/devspace/list.ts)_
 
 ## `fmc devspace:services [NAME]`
 
@@ -153,7 +153,7 @@ EXAMPLE
   $ fmc devspace:services
 ```
 
-_See code: [src/commands/devspace/services.ts](https://github.com/formicarium/fmc/blob/v1.4.26/src/commands/devspace/services.ts)_
+_See code: [src/commands/devspace/services.ts](https://github.com/formicarium/fmc/blob/v1.4.27/src/commands/devspace/services.ts)_
 
 ## `fmc devspace:use NAME`
 
@@ -170,7 +170,7 @@ EXAMPLE
   $ fmc devspace:use paps
 ```
 
-_See code: [src/commands/devspace/use.ts](https://github.com/formicarium/fmc/blob/v1.4.26/src/commands/devspace/use.ts)_
+_See code: [src/commands/devspace/use.ts](https://github.com/formicarium/fmc/blob/v1.4.27/src/commands/devspace/use.ts)_
 
 ## `fmc git:push [SERVICENAME]`
 
@@ -188,7 +188,7 @@ EXAMPLE
   $ fmc git:push
 ```
 
-_See code: [src/commands/git/push.ts](https://github.com/formicarium/fmc/blob/v1.4.26/src/commands/git/push.ts)_
+_See code: [src/commands/git/push.ts](https://github.com/formicarium/fmc/blob/v1.4.27/src/commands/git/push.ts)_
 
 ## `fmc git:setup [NAME] [LOCALFOLDER]`
 
@@ -206,7 +206,7 @@ EXAMPLE
   $ fmc service:setup .
 ```
 
-_See code: [src/commands/git/setup.ts](https://github.com/formicarium/fmc/blob/v1.4.26/src/commands/git/setup.ts)_
+_See code: [src/commands/git/setup.ts](https://github.com/formicarium/fmc/blob/v1.4.27/src/commands/git/setup.ts)_
 
 ## `fmc help [COMMAND]`
 
@@ -242,7 +242,7 @@ EXAMPLES
   $ fmc repl purgatory common-repl
 ```
 
-_See code: [src/commands/repl.ts](https://github.com/formicarium/fmc/blob/v1.4.26/src/commands/repl.ts)_
+_See code: [src/commands/repl.ts](https://github.com/formicarium/fmc/blob/v1.4.27/src/commands/repl.ts)_
 
 ## `fmc service:delete NAME`
 
@@ -260,7 +260,7 @@ EXAMPLE
   $ fmc service:delete mancini
 ```
 
-_See code: [src/commands/service/delete.ts](https://github.com/formicarium/fmc/blob/v1.4.26/src/commands/service/delete.ts)_
+_See code: [src/commands/service/delete.ts](https://github.com/formicarium/fmc/blob/v1.4.27/src/commands/service/delete.ts)_
 
 ## `fmc service:deploy:image SERVICENAME`
 
@@ -279,7 +279,7 @@ EXAMPLES
   $ fmc service:deploy:image my-service --arg version=5cfc8f3
 ```
 
-_See code: [src/commands/service/deploy/image.ts](https://github.com/formicarium/fmc/blob/v1.4.26/src/commands/service/deploy/image.ts)_
+_See code: [src/commands/service/deploy/image.ts](https://github.com/formicarium/fmc/blob/v1.4.27/src/commands/service/deploy/image.ts)_
 
 ## `fmc service:deploy:local [SERVICENAME] [LOCALPATH]`
 
@@ -298,7 +298,7 @@ EXAMPLE
   $ fmc service:deploy:local -l . -f my-args.json my-service --arg version=1 --arg xablau=xpto
 ```
 
-_See code: [src/commands/service/deploy/local.ts](https://github.com/formicarium/fmc/blob/v1.4.26/src/commands/service/deploy/local.ts)_
+_See code: [src/commands/service/deploy/local.ts](https://github.com/formicarium/fmc/blob/v1.4.27/src/commands/service/deploy/local.ts)_
 
 ## `fmc service:logs NAME`
 
@@ -316,7 +316,7 @@ EXAMPLE
   $ fmc service:logs mancini
 ```
 
-_See code: [src/commands/service/logs.ts](https://github.com/formicarium/fmc/blob/v1.4.26/src/commands/service/logs.ts)_
+_See code: [src/commands/service/logs.ts](https://github.com/formicarium/fmc/blob/v1.4.27/src/commands/service/logs.ts)_
 
 ## `fmc service:restart NAME`
 
@@ -333,7 +333,7 @@ EXAMPLE
   $ fmc service:restart mancini
 ```
 
-_See code: [src/commands/service/restart.ts](https://github.com/formicarium/fmc/blob/v1.4.26/src/commands/service/restart.ts)_
+_See code: [src/commands/service/restart.ts](https://github.com/formicarium/fmc/blob/v1.4.27/src/commands/service/restart.ts)_
 
 ## `fmc service:status`
 
@@ -350,7 +350,7 @@ EXAMPLE
   $ fmc service:restart mancini
 ```
 
-_See code: [src/commands/service/status.ts](https://github.com/formicarium/fmc/blob/v1.4.26/src/commands/service/status.ts)_
+_See code: [src/commands/service/status.ts](https://github.com/formicarium/fmc/blob/v1.4.27/src/commands/service/status.ts)_
 
 ## `fmc setup URL`
 
@@ -367,5 +367,5 @@ EXAMPLE
   $ fmc setup https://soil.your.host.here
 ```
 
-_See code: [src/commands/setup.ts](https://github.com/formicarium/fmc/blob/v1.4.26/src/commands/setup.ts)_
+_See code: [src/commands/setup.ts](https://github.com/formicarium/fmc/blob/v1.4.27/src/commands/setup.ts)_
 <!-- commandsstop -->

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@formicarium/cli",
-  "version": "1.4.26",
+  "version": "1.4.27",
   "description": "A CLI to operate on Formicarium",
   "publishConfig": {
     "access": "public",
@@ -12,7 +12,7 @@
   },
   "bugs": "https://github.com/formicarium/fmc/issues",
   "dependencies": {
-    "@formicarium/common": "^1.2.21",
+    "@formicarium/common": "^1.2.22",
     "@oclif/command": "^1",
     "@oclif/config": "^1",
     "@oclif/plugin-help": "^2",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -62,6 +62,7 @@
     "test": "nyc mocha --forbid-only \"test/**/*.test.ts\"",
     "test:watch": "nyc mocha --forbid-only \"test/**/*.test.ts\" --watch",
     "lint": "tslint -p tsconfig.json -c tslint.json",
+    "lint:fix": "tslint --fix -p tsconfig.json -c tslint.json",
     "readme": "oclif-dev readme",
     "manifest": "oclif-dev manifest",
     "postpack": "rm -f oclif.manifest.json",

--- a/packages/cli/src/commands/devspace/delete.ts
+++ b/packages/cli/src/commands/devspace/delete.ts
@@ -24,11 +24,9 @@ export default class DevspaceDelete extends FMCCommand {
     if (await uiService.promptBoolean(`Confirm deleting ${name}? (y/n)`)) {
       uiService.warn(`Deleting ${name}...`)
       await soilService.deleteDevspace(name)
-      console.log(await this.currentDevspace())
-      console.log(name)
       if (await this.currentDevspace() === name) {
             await configService.unsetDevspaceConfig()
-        }
+      }
       uiService.success('Devspace Deleted')
     } else {
       uiService.info('Aborting Command')

--- a/packages/cli/src/commands/devspace/delete.ts
+++ b/packages/cli/src/commands/devspace/delete.ts
@@ -20,13 +20,13 @@ export default class DevspaceDelete extends FMCCommand {
   public async run() {
     const { args } = this.parse(DevspaceDelete)
     const { name } = args
-      const { soilService, uiService, configService } = this.system
+    const { soilService, uiService, configService } = this.system
     if (await uiService.promptBoolean(`Confirm deleting ${name}? (y/n)`)) {
       uiService.warn(`Deleting ${name}...`)
       await soilService.deleteDevspace(name)
-        console.log(await this.currentDevspace())
-        console.log(name)
-        if (await this.currentDevspace() === name) {
+      console.log(await this.currentDevspace())
+      console.log(name)
+      if (await this.currentDevspace() === name) {
             await configService.unsetDevspaceConfig()
         }
       uiService.success('Devspace Deleted')

--- a/packages/cli/src/commands/devspace/delete.ts
+++ b/packages/cli/src/commands/devspace/delete.ts
@@ -20,10 +20,15 @@ export default class DevspaceDelete extends FMCCommand {
   public async run() {
     const { args } = this.parse(DevspaceDelete)
     const { name } = args
-    const { soilService, uiService } = this.system
+      const { soilService, uiService, configService } = this.system
     if (await uiService.promptBoolean(`Confirm deleting ${name}? (y/n)`)) {
       uiService.warn(`Deleting ${name}...`)
       await soilService.deleteDevspace(name)
+        console.log(await this.currentDevspace())
+        console.log(name)
+        if (await this.currentDevspace() === name) {
+            await configService.unsetDevspaceConfig()
+        }
       uiService.success('Devspace Deleted')
     } else {
       uiService.info('Aborting Command')

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -20,11 +20,16 @@ export default class Setup extends FMCCommand {
     },
   ]
 
+  protected showDevspace(): boolean {
+    return false
+  }
+
   public async run() {
     const { uiService } = this.system
     const { args } = this.parse(Setup)
     const { url } = args
     await this.system.configService.setSoilURL(url)
+    await this.system.configService.unsetDevspaceConfig()
     uiService.info(`Formicarium is now pointing to ${url}`)
   }
 }

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -4,7 +4,7 @@
     "access": "public",
     "registry": "https://registry.npmjs.org/"
   },
-  "version": "1.2.21",
+  "version": "1.2.22",
   "main": "lib/index.js",
   "source": "src/index.ts",
   "license": "MIT",

--- a/packages/common/src/services/config.ts
+++ b/packages/common/src/services/config.ts
@@ -25,6 +25,7 @@ export interface IConfigService {
   readDevspaceConfig: () => Promise<IDevspaceConfig>
   readConfig: () => Promise<IConfigContent>
   setDevspaceConfig: (config: IDevspaceConfig) => Promise<void>
+  unsetDevspaceConfig: () => Promise<void>
   setSoilURL: (uri: string) => Promise<void>
 }
 export class ConfigService implements IConfigService {
@@ -58,6 +59,14 @@ export class ConfigService implements IConfigService {
       devspace: devspaceConfig,
     })
   }
+
+  public unsetDevspaceConfig = async (): Promise<void> => {
+    const currentConfig = await this.readConfig()
+    await fs.writeJson(configFilePath, {
+        ...currentConfig,
+        devspace: {},
+    })
+ }
 
   public setSoilURL = async (uri: string): Promise<void> => {
     const currentConfig = await this.readConfig()

--- a/packages/common/src/services/config.ts
+++ b/packages/common/src/services/config.ts
@@ -66,7 +66,7 @@ export class ConfigService implements IConfigService {
         ...currentConfig,
         devspace: {},
     })
- }
+  }
 
   public setSoilURL = async (uri: string): Promise<void> => {
     const currentConfig = await this.readConfig()

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@formicarium/tools",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "main": "index.js",
   "license": "MIT",
   "dependencies": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -15,7 +15,7 @@
       "build/*"
     ]
   },
-  "version": "1.0.21",
+  "version": "1.0.22",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org/"
@@ -24,7 +24,7 @@
   "source": true,
   "license": "MIT",
   "dependencies": {
-    "@formicarium/common": "^1.2.21",
+    "@formicarium/common": "^1.2.22",
     "ansi-to-react": "^3.3.1",
     "apollo-cache": "^1.1.16",
     "apollo-cache-inmemory": "^1.2.9",


### PR DESCRIPTION
After running commands like `fmc setup` and `fmc delete` it makes sense to unset the current devspace as it does not exist anymore. This prevents `fmc` from getting into a weird state. 