### PR TITLE
Fix old code deploying

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -20,7 +20,7 @@ $ npm install -g @formicarium/cli
 $ fmc COMMAND
 running command...
 $ fmc (-v|--version|version)
-@formicarium/cli/1.6.0 darwin-x64 node-v11.10.0
+@formicarium/cli/1.6.1 darwin-x64 node-v11.9.0
 $ fmc --help [COMMAND]
 USAGE
   $ fmc COMMAND
@@ -30,6 +30,7 @@ USAGE
 # Commands
 <!-- commands -->
 * [`fmc autocomplete [SHELL]`](#fmc-autocomplete-shell)
+* [`fmc config GETORSET CONFIGPATH`](#fmc-config-getorset-configpath)
 * [`fmc curl METHOD APPLICATIONNAME PATH`](#fmc-curl-method-applicationname-path)
 * [`fmc devspace:create ID`](#fmc-devspacecreate-id)
 * [`fmc devspace:delete NAME`](#fmc-devspacedelete-name)
@@ -73,6 +74,31 @@ EXAMPLES
 
 _See code: [@oclif/plugin-autocomplete](https://github.com/oclif/plugin-autocomplete/blob/v0.1.0/src/commands/autocomplete/index.ts)_
 
+## `fmc config GETORSET CONFIGPATH`
+
+Configures fmc CLI to one cluster
+
+```
+USAGE
+  $ fmc config GETORSET CONFIGPATH
+
+OPTIONS
+  -h, --help           show CLI help
+  -o, --output=output  [default: json] set output type
+  -x, --extended       show extra columns
+  --columns=columns    only show provided columns (comma-separated)
+  --csv                output is csv format
+  --filter=filter      filter property by partial string matching, ex: name=foo
+  --no-header          hide table header from output
+  --no-truncate        do not truncate output to fit screen
+  --sort=sort          property to sort by (prepend '-' for descending)
+
+EXAMPLE
+  $ fmc config get soilUrl
+```
+
+_See code: [src/commands/config.ts](https://github.com/formicarium/fmc/blob/v1.6.1/src/commands/config.ts)_
+
 ## `fmc curl METHOD APPLICATIONNAME PATH`
 
 Make a curl request to the service in the devspace being used. You can pass any extra arguments to curl at the end of the command
@@ -100,7 +126,7 @@ EXAMPLES
   $ fmc curl GET s0-purgatory /api/version
 ```
 
-_See code: [src/commands/curl.ts](https://github.com/formicarium/fmc/blob/v1.6.0/src/commands/curl.ts)_
+_See code: [src/commands/curl.ts](https://github.com/formicarium/fmc/blob/v1.6.1/src/commands/curl.ts)_
 
 ## `fmc devspace:create ID`
 
@@ -127,7 +153,7 @@ EXAMPLES
   $ fmc devspace:create acq --arg sharded
 ```
 
-_See code: [src/commands/devspace/create.ts](https://github.com/formicarium/fmc/blob/v1.6.0/src/commands/devspace/create.ts)_
+_See code: [src/commands/devspace/create.ts](https://github.com/formicarium/fmc/blob/v1.6.1/src/commands/devspace/create.ts)_
 
 ## `fmc devspace:delete NAME`
 
@@ -152,7 +178,7 @@ EXAMPLE
   $ fmc devspace:delete paps
 ```
 
-_See code: [src/commands/devspace/delete.ts](https://github.com/formicarium/fmc/blob/v1.6.0/src/commands/devspace/delete.ts)_
+_See code: [src/commands/devspace/delete.ts](https://github.com/formicarium/fmc/blob/v1.6.1/src/commands/devspace/delete.ts)_
 
 ## `fmc devspace:info`
 
@@ -177,7 +203,7 @@ EXAMPLE
   $ fmc devspace:info
 ```
 
-_See code: [src/commands/devspace/info.ts](https://github.com/formicarium/fmc/blob/v1.6.0/src/commands/devspace/info.ts)_
+_See code: [src/commands/devspace/info.ts](https://github.com/formicarium/fmc/blob/v1.6.1/src/commands/devspace/info.ts)_
 
 ## `fmc devspace:list`
 
@@ -202,7 +228,7 @@ EXAMPLE
   $ fmc devspace:list
 ```
 
-_See code: [src/commands/devspace/list.ts](https://github.com/formicarium/fmc/blob/v1.6.0/src/commands/devspace/list.ts)_
+_See code: [src/commands/devspace/list.ts](https://github.com/formicarium/fmc/blob/v1.6.1/src/commands/devspace/list.ts)_
 
 ## `fmc devspace:services [NAME]`
 
@@ -227,7 +253,7 @@ EXAMPLE
   $ fmc devspace:services
 ```
 
-_See code: [src/commands/devspace/services.ts](https://github.com/formicarium/fmc/blob/v1.6.0/src/commands/devspace/services.ts)_
+_See code: [src/commands/devspace/services.ts](https://github.com/formicarium/fmc/blob/v1.6.1/src/commands/devspace/services.ts)_
 
 ## `fmc devspace:use NAME`
 
@@ -252,7 +278,7 @@ EXAMPLE
   $ fmc devspace:use paps
 ```
 
-_See code: [src/commands/devspace/use.ts](https://github.com/formicarium/fmc/blob/v1.6.0/src/commands/devspace/use.ts)_
+_See code: [src/commands/devspace/use.ts](https://github.com/formicarium/fmc/blob/v1.6.1/src/commands/devspace/use.ts)_
 
 ## `fmc git:push [SERVICENAME]`
 
@@ -278,7 +304,7 @@ EXAMPLE
   $ fmc git:push
 ```
 
-_See code: [src/commands/git/push.ts](https://github.com/formicarium/fmc/blob/v1.6.0/src/commands/git/push.ts)_
+_See code: [src/commands/git/push.ts](https://github.com/formicarium/fmc/blob/v1.6.1/src/commands/git/push.ts)_
 
 ## `fmc git:setup [NAME] [LOCALFOLDER]`
 
@@ -304,7 +330,7 @@ EXAMPLE
   $ fmc service:setup .
 ```
 
-_See code: [src/commands/git/setup.ts](https://github.com/formicarium/fmc/blob/v1.6.0/src/commands/git/setup.ts)_
+_See code: [src/commands/git/setup.ts](https://github.com/formicarium/fmc/blob/v1.6.1/src/commands/git/setup.ts)_
 
 ## `fmc help [COMMAND]`
 
@@ -348,7 +374,7 @@ EXAMPLES
   $ fmc repl purgatory common-repl
 ```
 
-_See code: [src/commands/repl.ts](https://github.com/formicarium/fmc/blob/v1.6.0/src/commands/repl.ts)_
+_See code: [src/commands/repl.ts](https://github.com/formicarium/fmc/blob/v1.6.1/src/commands/repl.ts)_
 
 ## `fmc service:delete NAME`
 
@@ -374,7 +400,7 @@ EXAMPLE
   $ fmc service:delete mancini
 ```
 
-_See code: [src/commands/service/delete.ts](https://github.com/formicarium/fmc/blob/v1.6.0/src/commands/service/delete.ts)_
+_See code: [src/commands/service/delete.ts](https://github.com/formicarium/fmc/blob/v1.6.1/src/commands/service/delete.ts)_
 
 ## `fmc service:deploy:image SERVICENAME`
 
@@ -385,24 +411,23 @@ USAGE
   $ fmc service:deploy:image SERVICENAME
 
 OPTIONS
-  -a, --arg=arg            an arg to be sent to config server
-  -f, --filePath=filePath
-  -h, --help               show CLI help
-  -o, --output=output      [default: table] set output type
-  -x, --extended           show extra columns
-  --columns=columns        only show provided columns (comma-separated)
-  --csv                    output is csv format
-  --filter=filter          filter property by partial string matching, ex: name=foo
-  --no-header              hide table header from output
-  --no-truncate            do not truncate output to fit screen
-  --sort=sort              property to sort by (prepend '-' for descending)
+  -a, --arg=arg        an arg to be sent to config server
+  -h, --help           show CLI help
+  -o, --output=output  [default: table] set output type
+  -x, --extended       show extra columns
+  --columns=columns    only show provided columns (comma-separated)
+  --csv                output is csv format
+  --filter=filter      filter property by partial string matching, ex: name=foo
+  --no-header          hide table header from output
+  --no-truncate        do not truncate output to fit screen
+  --sort=sort          property to sort by (prepend '-' for descending)
 
 EXAMPLES
   $ fmc service:deploy:image my-service
   $ fmc service:deploy:image my-service --arg version=5cfc8f3
 ```
 
-_See code: [src/commands/service/deploy/image.ts](https://github.com/formicarium/fmc/blob/v1.6.0/src/commands/service/deploy/image.ts)_
+_See code: [src/commands/service/deploy/image.ts](https://github.com/formicarium/fmc/blob/v1.6.1/src/commands/service/deploy/image.ts)_
 
 ## `fmc service:deploy:local [SERVICENAME] [LOCALPATH]`
 
@@ -429,7 +454,7 @@ EXAMPLE
   $ fmc service:deploy:local -l . -f my-args.json my-service --arg version=1 --arg xablau=xpto
 ```
 
-_See code: [src/commands/service/deploy/local.ts](https://github.com/formicarium/fmc/blob/v1.6.0/src/commands/service/deploy/local.ts)_
+_See code: [src/commands/service/deploy/local.ts](https://github.com/formicarium/fmc/blob/v1.6.1/src/commands/service/deploy/local.ts)_
 
 ## `fmc service:deploy:set [FILEPATH]`
 
@@ -454,7 +479,7 @@ EXAMPLE
   $ fmc service:deploy:set my-set.json
 ```
 
-_See code: [src/commands/service/deploy/set.ts](https://github.com/formicarium/fmc/blob/v1.6.0/src/commands/service/deploy/set.ts)_
+_See code: [src/commands/service/deploy/set.ts](https://github.com/formicarium/fmc/blob/v1.6.1/src/commands/service/deploy/set.ts)_
 
 ## `fmc service:logs NAME`
 
@@ -480,7 +505,7 @@ EXAMPLE
   $ fmc service:logs mancini
 ```
 
-_See code: [src/commands/service/logs.ts](https://github.com/formicarium/fmc/blob/v1.6.0/src/commands/service/logs.ts)_
+_See code: [src/commands/service/logs.ts](https://github.com/formicarium/fmc/blob/v1.6.1/src/commands/service/logs.ts)_
 
 ## `fmc service:restart NAME`
 
@@ -505,7 +530,7 @@ EXAMPLE
   $ fmc service:restart mancini
 ```
 
-_See code: [src/commands/service/restart.ts](https://github.com/formicarium/fmc/blob/v1.6.0/src/commands/service/restart.ts)_
+_See code: [src/commands/service/restart.ts](https://github.com/formicarium/fmc/blob/v1.6.1/src/commands/service/restart.ts)_
 
 ## `fmc service:status`
 
@@ -530,7 +555,7 @@ EXAMPLE
   $ fmc service:restart mancini
 ```
 
-_See code: [src/commands/service/status.ts](https://github.com/formicarium/fmc/blob/v1.6.0/src/commands/service/status.ts)_
+_See code: [src/commands/service/status.ts](https://github.com/formicarium/fmc/blob/v1.6.1/src/commands/service/status.ts)_
 
 ## `fmc setup URL`
 
@@ -555,5 +580,5 @@ EXAMPLE
   $ fmc setup https://soil.your.host.here
 ```
 
-_See code: [src/commands/setup.ts](https://github.com/formicarium/fmc/blob/v1.6.0/src/commands/setup.ts)_
+_See code: [src/commands/setup.ts](https://github.com/formicarium/fmc/blob/v1.6.1/src/commands/setup.ts)_
 <!-- commandsstop -->

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@formicarium/cli",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "A CLI to operate on Formicarium",
   "publishConfig": {
     "access": "public",
@@ -12,7 +12,7 @@
   },
   "bugs": "https://github.com/formicarium/fmc/issues",
   "dependencies": {
-    "@formicarium/common": "^1.4.0",
+    "@formicarium/common": "^1.4.1",
     "@oclif/command": "^1",
     "@oclif/config": "^1",
     "@oclif/plugin-autocomplete": "^0.1.0",

--- a/packages/cli/src/commands/service/delete.ts
+++ b/packages/cli/src/commands/service/delete.ts
@@ -31,7 +31,7 @@ export default class ServiceDelete extends FMCCommand {
       const apps = await soilService.getService(devspace.name, name)
       await soilService.deleteService(devspace.name, name)
       uiService.warn(`Deleting remote repos for ${name} from ${devspace.name}...`)
-      await apps.forEach(app => {
+      await apps.forEach((app) => {
         tanajuraService.deleteRepo(config.devspace.tanajuraApiUrl, app.name)
       })
       uiService.warn(`Deleting local repo on ${repoPath}...`)

--- a/packages/cli/src/commands/service/delete.ts
+++ b/packages/cli/src/commands/service/delete.ts
@@ -1,6 +1,6 @@
 import { flags as Flags } from '@oclif/command'
 import FMCCommand from '../../FMCCommand'
-
+import {IService} from '@formicarium/common/src/services/db'
 export default class ServiceDelete extends FMCCommand {
   public static description = 'Deletes a service in the current Devspace'
 
@@ -19,15 +19,23 @@ export default class ServiceDelete extends FMCCommand {
   ]
 
   public async run() {
-    const { configService, soilService, uiService } = this.system
+    const { configService, localDB, gitService, soilService, uiService, tanajuraService } = this.system
     const { args } = this.parse(ServiceDelete)
     const { name } = args
 
     const config = await configService.readConfig()
     const { devspace } = config
+    const { repoPath } = await localDB.getService(devspace.name, name) as IService
     if (await uiService.promptBoolean(`Confirm deleting ${name} from ${devspace.name}? (y/n)`)) {
       uiService.warn(`Deleting ${name} from ${devspace.name}...`)
+      const apps = await soilService.getService(devspace.name, name)
       await soilService.deleteService(devspace.name, name)
+      uiService.warn(`Deleting remote repos for ${name} from ${devspace.name}...`)
+      await apps.forEach(app => {
+        tanajuraService.deleteRepo(config.devspace.tanajuraApiUrl, app.name)
+      })
+      uiService.warn(`Deleting local repo on ${repoPath}...`)
+      gitService.deleteRepo(repoPath)
       uiService.success('Service Deleted')
     } else {
       uiService.info('Aborting Command')

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -4,7 +4,7 @@
     "access": "public",
     "registry": "https://registry.npmjs.org/"
   },
-  "version": "1.4.0",
+  "version": "1.4.1",
   "main": "lib/index.js",
   "source": "src/index.ts",
   "license": "MIT",

--- a/packages/common/src/services/db.ts
+++ b/packages/common/src/services/db.ts
@@ -1,7 +1,7 @@
 import { LowdbAsync } from 'lowdb'
 import { Maybe } from '../utils/types'
 
-interface IService {
+export interface IService {
   name: string
   repoPath: string
   stingerUrls: string[]

--- a/packages/common/src/services/git.ts
+++ b/packages/common/src/services/git.ts
@@ -16,13 +16,14 @@ export interface IGitService {
   getRemotes: (basePath: string) => Promise<RemoteWithRefs[]>
   removeRemote: (basePath: string, remoteName: string) => Promise<void>
   checkIfRepo: (basePath: string) => Promise<boolean>
+  deleteRepo: (basePath: string) => Promise<void>
   gitAddAll: (basePath: string) => Promise<void>
   gitCommit: (basePath: string, skipPull?: boolean) => Promise<gitP.CommitSummary>
   createMirrorRepo: (basePath: string) => Promise<void>
   alreadyHasMirrorRepo: (basePath: string) => Promise<boolean>
 }
 
-export class GitService {
+export class GitService implements IGitService {
   private static ORIGINAL_GIT_FOLDER = '.git'
   private static MIRROR_GIT_FOLDER = '.fmcgit'
 
@@ -111,4 +112,9 @@ export class GitService {
   }
 
   public alreadyHasMirrorRepo = async (basePath: string): Promise<boolean> => fs.pathExists(this.getMirrorGitRepoPath(basePath))
+
+  public deleteRepo = async (basePath: string): Promise<void> => {
+    const gitpath = `${basePath}/${GitService.MIRROR_GIT_FOLDER}`
+    fs.removeSync(gitpath)
+  }
 }

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@formicarium/tools",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "main": "index.js",
   "license": "MIT",
   "dependencies": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -15,7 +15,7 @@
       "build/*"
     ]
   },
-  "version": "1.1.0",
+  "version": "1.1.1",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org/"
@@ -24,7 +24,7 @@
   "source": true,
   "license": "MIT",
   "dependencies": {
-    "@formicarium/common": "^1.4.0",
+    "@formicarium/common": "^1.4.1",
     "ansi-to-react": "^3.3.1",
     "apollo-cache": "^1.1.16",
     "apollo-cache-inmemory": "^1.2.9",


### PR DESCRIPTION
When you run 
```
fmc service:deploy:local <svc> .
fmc service:delete <svc>
fmc service:deploy:local <svc> .
```
the second time deploys the first time's code 